### PR TITLE
Add merge support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "LazyJsonUndoRedo",
   "main": "LazyJsonUndoRedo.js",
-  "version": "0.9.7",
+  "version": "0.10.2",
   "homepage": "https://github.com/azazdeaz/LazyJsonUndoRedo",
   "authors": [
     "polgar andras <azazdeaz@gmail.com>"


### PR DESCRIPTION
I am using this in my SVG editor like project.

I moved shape A from position (x0, y0) to (x1, y1) , and then want to undo this operation. `ljur.undo` should change position to (x0, y0) instead of (x1 - 1, y1).